### PR TITLE
Add setting to disable fancy jumps

### DIFF
--- a/mod.toml
+++ b/mod.toml
@@ -68,7 +68,9 @@ Vanilla: Use default game behavior
 
 Cycle: Cycle jump animation in the order Normal -> Roll -> Somersault
 
-Random: Choose a jumping animation at random"""
+Random: Choose a jumping animation at random
+
+Disabled: Disable fancy jumping entirely"""
 type = "Enum"
-options = [ "Vanilla", "Cycle", "Random" ]
+options = [ "Vanilla", "Cycle", "Random", "Disabled" ]
 default = "Cycle"

--- a/src/fancy_jumps.c
+++ b/src/fancy_jumps.c
@@ -8,7 +8,8 @@ typedef enum
 {
     MOD_OPT_VANILLA,
     MOD_OPT_CYCLE,
-    MOD_OPT_RANDOM
+    MOD_OPT_RANDOM,
+    MOD_OPT_DISABLED
 } FancyJumpsSelectOption;
 
 extern FloorProperty sPrevFloorProperty;
@@ -43,6 +44,13 @@ RECOMP_HOOK("func_808373F8")
 void replaceFloorProperty(PlayState *play, Player *this, u16 sfxId)
 {
     realPrevFloorProperty = sPrevFloorProperty;
+
+    FancyJumpsSelectOption selectionMethod = recomp_get_config_u32("jump_selection_method");
+
+    if (selectionMethod == MOD_OPT_DISABLED) {
+        sPrevFloorProperty = FLOOR_PROPERTY_0;
+        return;
+    }
 
     if ((this->transformation != PLAYER_FORM_DEKU))
     {


### PR DESCRIPTION
Added a setting that removes fancy jumps entirely. 

This is useful to speedrunners and rando players because fancy jumps mess with things like grabbing ledges when doing bomb longjumps. I've tested this on my own setup, but this is my first mod for this game so I'd recommend checking my work!