### PR TITLE
Add option to allow roll out of fancy jump

### DIFF
--- a/mod.toml
+++ b/mod.toml
@@ -72,3 +72,14 @@ Random: Choose a jumping animation at random"""
 type = "Enum"
 options = [ "Vanilla", "Cycle", "Random" ]
 default = "Cycle"
+
+[[manifest.config_options]]
+id = "allow_roll_after_fancy_jump"
+name = "Allow Roll"
+description = """\
+On: Allow Link to roll out of a roll jump or side flip.
+
+Off: Link can only roll out of his normal jump. (Vanilla behavior)"""
+type = "Enum"
+options = [ "On", "Off" ]
+default = "Off"

--- a/src/fancy_jumps.c
+++ b/src/fancy_jumps.c
@@ -3,13 +3,21 @@
 #include "recomputils.h"
 #include "recompconfig.h"
 #include "rand.h"
+#include "z64animation.h"
+extern LinkAnimationHeader gPlayerAnim_link_normal_newroll_jump_20f;
 
-typedef enum
-{
+extern LinkAnimationHeader gPlayerAnim_link_normal_newside_jump_20f;
+
+typedef enum {
     MOD_OPT_VANILLA,
     MOD_OPT_CYCLE,
     MOD_OPT_RANDOM
 } FancyJumpsSelectOption;
+
+typedef enum {
+    MOD_OPT_ALWAYS_ALLOW_ROLL,
+    MOD_OPT_VANILLA_ALLOW_ROLL
+} FancyJumpsAllowRollOption;
 
 extern FloorProperty sPrevFloorProperty;
 
@@ -17,12 +25,10 @@ u8 currentJump = 0;
 
 FloorProperty realPrevFloorProperty = FLOOR_PROPERTY_0;
 
-u8 getNextJump()
-{
+u8 getNextJump() {
     u8 result = 0;
     FancyJumpsSelectOption selectionMethod = recomp_get_config_u32("jump_selection_method");
-    switch (selectionMethod)
-    {
+    switch (selectionMethod) {
     case MOD_OPT_CYCLE:
         result = currentJump % 3;
         ++currentJump;
@@ -39,9 +45,13 @@ u8 getNextJump()
     return result;
 }
 
+Player *player;
+PlayState *playState;
+
 RECOMP_HOOK("func_808373F8")
-void replaceFloorProperty(PlayState *play, Player *this, u16 sfxId)
-{
+void replaceFloorProperty(PlayState *play, Player *this, u16 sfxId) {
+    player = this;
+    playState = play;
     realPrevFloorProperty = sPrevFloorProperty;
 
     if ((this->transformation != PLAYER_FORM_DEKU))
@@ -78,4 +88,25 @@ RECOMP_HOOK_RETURN("func_808373F8")
 void restoreFloorProperty()
 {
     sPrevFloorProperty = realPrevFloorProperty;
+}
+
+bool shouldRollAfterJump(Player *this) {
+    return (this->fallDistance > 80) && (this->fallDistance < 800) &&
+           (this->controlStickDirections[this->controlStickDataIndex] == PLAYER_STICK_DIR_FORWARD) &&
+           !(this->stateFlags1 & PLAYER_STATE1_CARRYING_ACTOR);
+}
+
+RECOMP_HOOK("func_80837134")
+void onJumpEnd(PlayState *play, Player *this) {
+
+    if (recomp_get_config_u32("allow_roll_after_fancy_jump") == MOD_OPT_ALWAYS_ALLOW_ROLL) {
+        if (this->transformation != PLAYER_FORM_DEKU) {
+            LinkAnimationHeader *animation = this->skelAnime.animation;
+            if (animation == &gPlayerAnim_link_normal_newside_jump_20f || animation == &gPlayerAnim_link_normal_newside_jump_20f) {
+                if (shouldRollAfterJump(this)) {
+                    player->stateFlags2 &= ~PLAYER_STATE2_80000;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
By default, Link is locked from rolling to avoid damage when he is doing a side flip or roll jump. This is a QoL feature that allows Link to roll to mitigate fall damage when doing one of his special jump types.